### PR TITLE
Fix #37: Clean up build warnings

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -29,7 +29,7 @@
 */
 #include <stdio.h>
 #include <stdlib.h>
-#include "getopt.h"
+#include <getopt.h>
 #include <string.h>
 #include <limits.h>
 #include "SendUdp.h"
@@ -383,7 +383,7 @@ int main(int argc, char *argv[]) {
     int   opt = 0;
     int   longIndex = 0;
     int   retStat;
-    short tempShort;
+    unsigned short tempShort;
 
     /*
     ** Initialize the CommandData struct


### PR DESCRIPTION
**Describe the contribution**
Fixes #37 

**Testing performed**
Steps taken to test the contribution:
1. Built with "-Wall -Wstrict-prototypes -std=c99 -pedantic -Wcast-align -D_XOPEN_SOURCE=600"
1. Executed cfe-core
1. Sent reset and noop commands from cmdUtil

**Expected behavior changes**
No more build warnings

**System(s) tested on:**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 16.04
 - Versions: master bundle with this change

**Additional context**
N/A

**Contributor Info**
Jacob Hageman - NASA/GSFC