### PR TITLE
Fix #40, GUI Command definitions

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -109,6 +109,7 @@ static struct option longOpts[] = {
     { "long",      required_argument, NULL, 'l' },
     { "double",    required_argument, NULL, 'd' },
     { "string",    required_argument, NULL, 's' },
+    { "word",      required_argument, NULL, 'l' },
     { "help",      no_argument,       NULL, '?' },
     { "verbose",   no_argument,       NULL, 'v' },
     { NULL,        no_argument,       NULL, 0   }


### PR DESCRIPTION
**Describe the contribution**
Fixes issue #40 

Temporary/quick fix for issue 40.

**Testing performed**
   1. Recreated issue as stated 
   2. Updated cmdUtil...followed by nominal build process
   3. Successfully sent a number of commands that contain --word parameter

**Expected behavior changes**
   Commands utilizing --word parameter will now work

**System(s) tested on:**
   Oracle VM VirtualBox
   OS: ubuntu-19.10
   Version: cFE 6.7.3.0; OSAL 5.0.3.0; PSP 1.4.1.0

**Contributor Info**
Dan Knutsen
GSFC/NASA

