### PR TITLE
Fix #52, Python3 and tlm processing

### DIFF
--- a/GroundSystem.py
+++ b/GroundSystem.py
@@ -87,12 +87,12 @@ class GroundSystem(QtGui.QMainWindow):
             subscription = '--sub=GroundSystem.' + selectedSpacecraft + '.TelemetryPackets'
 
         # Open Telemetry System
-        system_call = '( cd Subsystems/tlmGUI/ && python TelemetrySystem.py ' + subscription + ' ) & '
+        system_call = '( cd Subsystems/tlmGUI/ && python3 TelemetrySystem.py ' + subscription + ' ) & '
         os.system(system_call)
 
     # Start command system
     def startCmdSystem(self):
-        os.system('( cd Subsystems/cmdGui/ && python CommandSystem.py ) & ')
+        os.system('( cd Subsystems/cmdGui/ && python3 CommandSystem.py ) & ')
 
     # Start FDL-FUL gui system
     #def startFDLSystem(self):

--- a/RoutingService.py
+++ b/RoutingService.py
@@ -71,8 +71,6 @@ class RoutingService(QtCore.QThread):
                     # Receive message
                     datagram, host = self.sock.recvfrom(4096) # buffer size is 1024 bytes
 
-                    print ('length datagram: %d' % len(datagram))
-
                     # Ignore datagram if it is not long enough (doesnt contain tlm header?)
                     if len(datagram) < 6:
                         continue

--- a/Subsystems/cmdGui/CommandSystem.py
+++ b/Subsystems/cmdGui/CommandSystem.py
@@ -144,9 +144,8 @@ class CommandSystem(QtGui.QDialog):
            lineEditAddress = getattr(Command.ui, 'lineEdit_'+str(idx))
            pktId = str(lineEditPktId.text())
            address = str(lineEditAddress.text())
-           launch_string = 'python ' + cmdClass[0] + ' --title=\"' + cmdPageDesc[idx] + '\" --pktid=' + pktId + ' --file=' + cmdPageDefFile[idx] + ' --address=\"' + address + '\"' + ' --port=' + str(cmdPagePort[idx]) + ' --endian=' + cmdPageEndian[idx]
+           launch_string = 'python3 ' + cmdClass[0] + ' --title=\"' + cmdPageDesc[idx] + '\" --pktid=' + pktId + ' --file=' + cmdPageDefFile[idx] + ' --address=\"' + address + '\"' + ' --port=' + str(cmdPagePort[idx]) + ' --endian=' + cmdPageEndian[idx]
            cmd_args = shlex.split(launch_string)
-           print launch_string
            subprocess.Popen(cmd_args)
 
     #
@@ -227,14 +226,12 @@ class CommandSystem(QtGui.QDialog):
 
            # if requires parameters
            if self.checkParams(quickIdx) == True:
-              prog = 'python Parameter.py'
+              prog = 'python3 Parameter.py'
               launch_string = prog+' --title=\"'+subsys[quickIdx]+'\" --descrip=\"'+quickCmd[quickIdx]+'\" --idx='+str(idx)+' --host=\"'+address+'\" --port='+str(quickPort[quickIdx])+' --pktid='+pktId+' --endian='+quickEndian[quickIdx]+' --cmdcode='+quickCode[quickIdx]+' --file='+quickParam[quickIdx]
 
            # if doesn't require parameters
            else:
                launch_string = '../cmdUtil/cmdUtil' + ' --host=\"' + address + '\" --port=' + str(quickPort[quickIdx]) + ' --pktid=' + pktId + ' --endian=' + quickEndian[quickIdx] + ' --cmdcode=' + quickCode[quickIdx]
-
-           # print launch_string
            cmd_args = shlex.split(launch_string)
            subprocess.Popen(cmd_args)
 
@@ -269,7 +266,7 @@ if __name__ == '__main__':
 
     i = 0
 
-    with open(cmdDefFile, 'rb') as cmdfile:
+    with open(cmdDefFile, 'r') as cmdfile:
         reader = csv.reader(cmdfile, skipinitialspace = True)
         for cmdRow in reader:
             try:
@@ -284,9 +281,9 @@ if __name__ == '__main__':
                     cmdPagePort.append(int(cmdRow[6]))
                     i += 1
             except IndexError:
-                print "IndexError: list index out of range"
-                print "This could be due to improper formatting in command-pages.txt."
-                print "This is a common error caused by blank lines in command-pages.txt"
+                print ("IndexError: list index out of range")
+                print ("This could be due to improper formatting in command-pages.txt.")
+                print ("This is a common error caused by blank lines in command-pages.txt")
 
     # 
     # Mark the remaining values as invalid
@@ -311,7 +308,7 @@ if __name__ == '__main__':
     quickParam = []
     quickIndices = []
 
-    with open(quickDefFile,'rb') as subFile:
+    with open(quickDefFile,'r') as subFile:
        reader = csv.reader(subFile)
        i = 0
        for fileRow in reader:
@@ -644,6 +641,6 @@ if __name__ == '__main__':
     #
     Command.show()
     Command.raise_()
-    print 'Command System started.'
+    print ('Command System started.')
     sys.exit(app.exec_())
 

--- a/Subsystems/cmdGui/HTMLDocsParser.py
+++ b/Subsystems/cmdGui/HTMLDocsParser.py
@@ -26,7 +26,7 @@ import re
 import glob
 import pickle
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 from struct import *
 
 class HTMLDocsParser(HTMLParser):
@@ -155,15 +155,15 @@ if __name__ == '__main__':
 						stringLen.append(keyword)
 
 
-				print "DATA TYPES:", dataTypesOrig
-				print "PARAM NAMES: ", paramNames
-				print "PARAM STRING LEN:", paramLen
-				print "PARAM DESC: ", paramDesc
-				print "UNIX DATA TYPES:", dataTypesNew
-				print "STRING LENGTH:", stringLen, "\n"
+				print ("DATA TYPES:", dataTypesOrig)
+				print ("PARAM NAMES: ", paramNames)
+				print ("PARAM STRING LEN:", paramLen)
+				print ("PARAM DESC: ", paramDesc)
+				print ("UNIX DATA TYPES:", dataTypesNew)
+				print ("STRING LENGTH:", stringLen, "\n")
 
 			except ValueError:
-				print "Data Fields not found in HTML file"
+				print ("Data Fields not found in HTML file")
 
 			# write data to a file
 			file_split = re.split('/|\.', html_file)

--- a/Subsystems/cmdGui/Parameter.py
+++ b/Subsystems/cmdGui/Parameter.py
@@ -27,7 +27,7 @@ import pickle
 
 from PyQt4 import QtGui, QtNetwork
 from ParameterDialog import Ui_Dialog
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 from HTMLDocsParser import HTMLDocsParser
 from struct import *
 

--- a/Subsystems/cmdGui/UdpCommands.py
+++ b/Subsystems/cmdGui/UdpCommands.py
@@ -40,7 +40,7 @@ import pickle
 
 from PyQt4 import QtGui
 from GenericCommandDialog import Ui_GenericCommandDialog
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 from HTMLDocsParser import HTMLDocsParser
 from struct import *
 
@@ -166,7 +166,7 @@ class SubsystemCommands(QtGui.QDialog):
             
             # If parameters are required, launches Parameters page
             if param_bool == True:
-                prog = 'python Parameter.py'
+                prog = 'python3 Parameter.py'
                 launch_string = prog+' --title=\"'+pageTitle+'\" --descrip=\"'+cmdDesc[idx]+'\" --idx='+str(idx)+' --host=\"'+address+'\" --port='+str(pagePort)+' --pktid='+str(pagePktId)+' --endian='+pageEndian+' --cmdcode='+cmdCodes[idx]+' --file='+param_files[idx]
 
             # If parameters not required, directly calls cmdUtil to send command
@@ -183,8 +183,8 @@ class SubsystemCommands(QtGui.QDialog):
 # Display usage
 #
 def usage():
-    print "Must specify --title=<page name> --file=<cmd_def_file> --pktid=<packet_app_id(hex)> --endian=<LE|BE> --address=<IP address> --port=<UDP port>" 
-    print "     example: --title=\"Executive Services\" --file=cfe-es-cmds.txt --pktid=1806  --endian=LE --address=127.0.0.1 --port=1234" 
+    print ("Must specify --title=<page name> --file=<cmd_def_file> --pktid=<packet_app_id(hex)> --endian=<LE|BE> --address=<IP address> --port=<UDP port>") 
+    print ("     example: --title=\"Executive Services\" --file=cfe-es-cmds.txt --pktid=1806  --endian=LE --address=127.0.0.1 --port=1234") 
 
 #
 # Main 

--- a/Subsystems/tlmGUI/TelemetrySystem.py
+++ b/Subsystems/tlmGUI/TelemetrySystem.py
@@ -81,9 +81,9 @@ class TelemetrySystem(QtGui.QDialog):
          appIdString = "%02X" % ord(packetData[0])
          appIdString = appIdString + "%02X" % ord(packetData[1])
          appId = (ord(packetData[0]) << 8) + (ord(packetData[1]))
-         print "\n-----------------------------------------------"
-         print "\nPacket: App ID = ",  hex(appId)
-         print "\nPacket Data: ", strToHex(packetData)
+         print ("\n-----------------------------------------------")
+         print ("\nPacket: App ID = ",  hex(appId))
+         print ("\nPacket Data: ", strToHex(packetData))
 
     #
     # Button press methods
@@ -135,7 +135,7 @@ class TelemetrySystem(QtGui.QDialog):
         tempSub = self.subscription + '.' + hex(tlmPageAppid[idx])
         if tlmPageIsValid[idx] == True:
            # need to extract data from fields, then start page with right params
-           launch_string = 'python ' + tlmClass[idx] + ' --title=\"' + tlmPageDesc[idx] + '\" --appid=' + hex(tlmPageAppid[idx]) + ' --port=' + str(tlmPagePort[idx]) + ' --file=' + tlmPageDefFile[idx] + ' --endian=' + endian + ' --sub=' + tempSub
+           launch_string = 'python3 ' + tlmClass[idx] + ' --title=\"' + tlmPageDesc[idx] + '\" --appid=' + hex(tlmPageAppid[idx]) + ' --port=' + str(tlmPagePort[idx]) + ' --file=' + tlmPageDefFile[idx] + ' --endian=' + endian + ' --sub=' + tempSub
            cmd_args = shlex.split(launch_string)
            subprocess.Popen(cmd_args)
     
@@ -168,10 +168,9 @@ class TelemetrySystem(QtGui.QDialog):
             appIdString = "%02X" % ord(packetData[0])
             appIdString = appIdString + "%02X" % ord(packetData[1])
             appId = (ord(packetData[0]) << 8) + (ord(packetData[1]))
-            print appIdString
-            print "\nPacket: App ID = ",  hex(appId)
-            print "\nPacket Data: ", strToHex(packetData)
-            print "\n-----------------------------------------------"
+            print ("\nPacket: App ID = ",  hex(appId))
+            print ("\nPacket Data: ", strToHex(packetData))
+            print ("\n-----------------------------------------------")
 
         #
         # Show number of packets received
@@ -256,7 +255,7 @@ class TlmReceiver(QtCore.QThread):
         self.context   = zmq.Context()
         self.subscriber = self.context.socket(zmq.SUB)
         self.subscriber.connect("ipc:///tmp/GroundSystem")
-        self.subscriber.setsockopt(zmq.SUBSCRIBE, subscription)
+        self.subscriber.setsockopt_string(zmq.SUBSCRIBE, subscription)
     
     def run(self):
         while True:
@@ -300,7 +299,7 @@ if __name__ == '__main__':
     if len(subscription) == 0:
         subscription = "GroundSystem"
 
-    print 'Telemetry System started. Subscribed to ' + subscription
+    print ('Telemetry System started. Subscribed to ' + subscription)
     #
     # Read in the contents of the telemetry packet defintion
     #
@@ -313,7 +312,7 @@ if __name__ == '__main__':
     tlmPageDefFile = []
     i = 0
 
-    with open(tlmDefFile, 'rb') as tlmfile:
+    with open(tlmDefFile, 'r') as tlmfile:
        reader = csv.reader(tlmfile, skipinitialspace = True)
        for row in reader:
           if row[0][0] != '#':


### PR DESCRIPTION
**Describe the contribution**
Fix #52, Python3 and tlm processing

**Testing performed**
1. Launched cFS Ground System (GroundSystem.py)
2. Started Command and Telemetry System
3. Enabled Tlm on 127.0.0.1
4. Opened Event Message and Executive Services telemetry pages - verified telemetry nominal.
5. Sent a ES No-OP.
6. Verified that Event Message tlm page updated successfully and that the command counter on the Executive Services Tlm page incremented.

**Expected behavior changes**
All of the scripts should now be updated to work with python 3.
Telemetry System should now work/be able to be used to view telemetry.

**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Version: cFE 6.7.3.0; OSAL 5.0.3.0; PSP 1.4.1.0

**Contributor Info**
Dan Knutsen
GSFC/NASA