### PR TITLE
Fix #65, CCSDS Command Secondary Header Endian Agnostic

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -441,20 +441,8 @@ int main(int argc, char *argv[]) {
                 fprintf(stderr,"Command Code Argument: '%s' rejected. Number is too large.\n",optarg);
                 break;
             }
-            /* 
-            ** Shift the command code to the upper 8 bits of the word 
-            */
-	    tempShort <<= 8;
 
-            /*
-            ** Swap if needed 
-            */
-            if (hostByteOrder != CommandData.Endian) 
-            {
-               byteSwap((char*)&tempShort, sizeof(tempShort));
-            }
-
-            memcpy(&CommandData.PacketHdr[6], &tempShort, sizeof(tempShort));
+            CommandData.PacketHdr[6] = tempShort;
             CommandData.GotCmdCode = 1;
             break;
 


### PR DESCRIPTION
**Describe the contribution**
Implement CCSDS command secondary header such that it is endian agnostic.  Really just sets command code appropriately.
Fix #65 

**Testing performed**
Steps taken to test the contribution:
1. Tested via bundle CI (including non-zero command send to reset)
1. Also tested locally with enabling TO via cFS-GroundSystem

This covered both direct cmdUtil call and cFS-GroundSystem use.

**Expected behavior changes**
Cmd code (and checksum) are always in the same place (matches GSFC spec for command secondary header)

**System(s) tested on**
 - Hardware: CI and cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: test bundle with this change and https://github.com/nasa/cFE/pull/568 in cfe

**Additional context**
See also https://github.com/nasa/cFE/pull/568, these two should be merged together

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC