### PR TITLE
Fix #76, warnings on strncpy

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -404,13 +404,15 @@ int main(int argc, char *argv[]) {
         {
         case 'H':
             printf("Host: %s\n",(char *)optarg);
-            strncpy(CommandData.HostName, optarg, HOSTNAME_SIZE);
+            strncpy(CommandData.HostName, optarg, HOSTNAME_SIZE-1);
+            CommandData.HostName[HOSTNAME_SIZE-1] = 0;
             CommandData.GotHostName = 1;
             break;
 
         case 'P':
             printf("Port: %s\n",(char *)optarg);
-            strncpy(CommandData.PortNum, optarg, PORTNUM_SIZE);
+            strncpy(CommandData.PortNum, optarg, PORTNUM_SIZE-1);
+            CommandData.PortNum[PORTNUM_SIZE-1] = 0;
             CommandData.GotPortNum = 1;
             break;
 


### PR DESCRIPTION
**Describe the contribution**
Fix possible non-truncated string in option parsing.
This generated a warning in GCC9.

Fixes #76 

**Testing performed**
Build code with default config, SIMULATION=native BUILDTYPE=release on GCC 9.3.0.
Confirm successful build with no warning.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04 LTS 64 bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

