### PR TITLE
Resolve #112, add build number and baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 cmdUtil
+!/Subsystems/cmdUtil
+CMakeFiles
+CMakeCache.txt
 .DS_Store

--- a/GroundSystem.py
+++ b/GroundSystem.py
@@ -31,6 +31,12 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox
 from RoutingService import RoutingService
 from Ui_MainWindow import Ui_MainWindow
 
+from _version import __version__ as _version
+from _version import _version_string
+
+__version__ = _version
+
+
 ROOTDIR = Path(sys.argv[0]).resolve().parent
 
 
@@ -167,7 +173,10 @@ class GroundSystem(QMainWindow, Ui_MainWindow):
 # Main
 #
 if __name__ == "__main__":
-
+    
+    # Report Version Number upon startup
+    print(_version_string)
+    
     # Init app
     app = QApplication(sys.argv)
 

--- a/_version.py
+++ b/_version.py
@@ -1,0 +1,49 @@
+#
+#  GSC-18128-1, "Core Flight Executive Version 6.7"
+#
+#  Copyright (c) 2006-2019 United States Government as represented by
+#  the Administrator of the National Aeronautics and Space Administration.
+#  All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# Development Build Macro Definitions
+_cFS_GrndSys_build_number = 73
+_cFS_GrndSys_build_baseline = "v2.1.0"
+
+# Version Number Definitions
+# ONLY APPLY for OFFICIAL release builds
+_cFS_GrndSys_MAJOR = 2
+_cFS_GrndSys_MINOR = 1
+_cFS_GrndSys_REVISION = 0
+_cFS_GrndSys_MISSIONREV = 0
+
+# Development Build format for __version__ 
+# Baseline git tag + Number of commits since baseline
+__version__ = "+dev".join((_cFS_GrndSys_build_baseline,str(_cFS_GrndSys_build_number)))
+
+# Development Build format for __version_string__ 
+_version_string = " cFS-GroundSystem Development Build\n " + __version__ + " (Codename: Bootes)"
+
+# Use the following templates for Official Releases ONLY 
+
+    # Official Release format for __version__ 
+    # __version__ = ".".join(map(str,(_cFS_GrndSys_MAJOR, _cFS_GrndSys_MINOR, _cFS_GrndSys_REVISION, _cFS_GrndSys_MISSIONREV)))
+    
+    # Official Release format for _version_string
+    # _version_string = " cFS-GroundSystem v" + __version__
+
+# END TEMPLATES
+


### PR DESCRIPTION
**Describe the contribution**
Resolve #112 

**Testing performed**
Ran ground system on OSX and confirmed version printout on stdout 

**Expected behavior changes**
Prints version number on startup
<img width="507" alt="Screen Shot 2020-07-21 at 11 49 36 AM" src="https://user-images.githubusercontent.com/59618057/88079834-3b3c9300-cb4c-11ea-93aa-77875fcb4351.png">


**System(s) tested on**
OSX 10.14.6
Python 3.8.3 

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC