### PR TITLE
Fix #128, strncpy should result in null term

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -814,7 +814,7 @@ int main(int argc, char *argv[])
                 }
 
                 /* Copy the data over (zero fills) */
-                strncpy(sbuf, &tail[1], sizeof(sbuf));
+                strncpy(sbuf, &tail[1], sizeof(sbuf) - 1);
                 CopyData(cmd.Packet, &startbyte, sbuf, tempull);
 
                 /* Reset tail so it doesn't trigger error */


### PR DESCRIPTION
**Describe the contribution**
Closes #128 

Reduce the size of the strncpy so that it ensures there's a null byte at the end of the string buffer.

**Testing performed**
make install, make test

**System(s) tested on**
Debian 10.5

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov