### PR TITLE
Integration Candidate: 2020-09-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ See [Guide-GroundSystem.md](https://github.com/nasa/cFS-GroundSystem/blob/master
 
 ## Version History
 
+### Development Build: 2.2.0-rc1+dev8
+
+- Replaces old code that caused a cast-align warning when strict. Refactored and removed unnecessary code while also following recommended model for getaddrinfo. Removed old windows support/defines/etc (likely not tested for years, no longer supported).
+- Reduce the size of the strncpy so that it ensures there's a null byte at the end of the string buffer.
+- See <https://github.com/nasa/cFS-GroundSystem/pull/133>
+
 ### Development Build: 2.2.0+dev2
 
  - Fixes multiple typos

--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -814,7 +814,7 @@ int main(int argc, char *argv[])
                 }
 
                 /* Copy the data over (zero fills) */
-                strncpy(sbuf, &tail[1], sizeof(sbuf));
+                strncpy(sbuf, &tail[1], sizeof(sbuf) - 1);
                 CopyData(cmd.Packet, &startbyte, sbuf, tempull);
 
                 /* Reset tail so it doesn't trigger error */

--- a/_version.py
+++ b/_version.py
@@ -20,7 +20,7 @@
 #
 
 # Development Build Macro Definitions
-_cFS_GrndSys_build_number = 2
+_cFS_GrndSys_build_number = 8
 _cFS_GrndSys_build_baseline = "v2.2.0-rc1"
 
 # Version Number Definitions


### PR DESCRIPTION
**Describe the contribution**
Fix #93 
Fix #128 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/136/checks

**Expected behavior changes**
PR #130 - Replaces old code that caused a cast-align warning when strict.  Refactored and removed unnecessary code while also following recommended model for `getaddrinfo`.  Removed old windows support/defines/etc (likely not tested for years, no longer supported).

PR #129 - Reduce the size of the `strncpy` so that it ensures there's a null byte at the end of the string buffer.

**System(s) tested on**
Ubuntu - CI

**Additional context**
https://github.com/nasa/cFS/pull/136

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman, NASA-GSFC
Chris Knight, NASA-ARC