### PR TITLE
Fix #142, Create Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability for the cFS-GroundSystem subsystem please [submit an issue](https://github.com/nasa/cFS-GroundSystem/issues/new/choose).
+
+For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy).
+
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+
+## Additional Support
+
+For additional support, email us at cfs-program@lists.nasa.gov. For help using OSAL and cFS, [subscribe to our mailing list](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+
+If you wish to report a cybersecurity incident or concern please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.


### PR DESCRIPTION
**Describe the contribution**
Fix #142 
Created a draft of a security policy markdown file for cFS-GroundSystem. The purpose of a security policy is to inform users on how to submit bugs or vulnerabilities. It is ideal to include a section for supported versions.

**Additional context**
Optional sections that may be included:

- What to expect security-wise such as what type of testing is done
- Address privacy concerns
- Supported versions
- License
- Known vulnerabilities

References to Public Security Policies:
https://github.com/thanos-io/thanos/security/policy
https://github.com/minhealthnz/nzcovidtracer-app/security/policy
https://github.com/odoo/odoo/security/policy

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal