### PR TITLE
Fix #144, Pad cmdUtil header to 64 bit boundary

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -605,6 +605,9 @@ int main(int argc, char *argv[])
     if (cmd.IncludeCFSSec)
         startbyte += sizeof(cmd.CFS_CmdSecHdr);
 
+    /* Round up to account for padding */
+    startbyte += startbyte % 8;
+
     if (cmd.Verbose)
     {
         printf("Payload start byte = %u\n", startbyte);


### PR DESCRIPTION
**Describe the contribution**
Fix #144 - rounds header up to match nasa/cFE#1077

**Testing performed**
Sent command to cFE with extended header, confirmed round up worked.

**Expected behavior changes**
Breaking change, behaves the same if cFE is run with nasa/cFE#1077

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + nasa/cFE#1077 + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC