### PR TITLE
Fix #155, Remove unnecessary type translations

### DIFF
--- a/Subsystems/cmdGui/CHeaderParser.py
+++ b/Subsystems/cmdGui/CHeaderParser.py
@@ -68,19 +68,15 @@ ROOTDIR = Path(sys.argv[0]).resolve().parent
 
 
 #
-# Determines data type (--string, --byte, --half, --word, --double)
+# Translate known data types to arguments
 #
 def findDataTypeNew(dataTypeOrig, paramName):
     if '[' in paramName:
         return '--string'
-    if dataTypeOrig in ['uint8', 'boolean']:
-        return '--byte'
-    if dataTypeOrig == 'uint16':
-        return '--half'
-    if dataTypeOrig == 'uint32':
-        return '--word'
-    if dataTypeOrig == 'uint64':
-        return '--double'
+    if dataTypeOrig in ['boolean']:
+        return '--uint8'
+    if dataTypeOrig in ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64']:
+        return "--" + dataTypeOrig
     return None
 
 


### PR DESCRIPTION
**Describe the contribution**
Fix #155 - removes unnecessary type translations from CHeaderParser.py (also removes broken "double")

**Testing performed**
Requesting test by @JackNWhite
Spot checked processing of int32's so at least the pattern is ok (and runs)

**Expected behavior changes**
`uint64` will no longer get translated by `CHeaderParser` into the unsupported `double` type

**System(s) tested on**
cFS Dev Server, Ubuntu 18.04

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC