### PR TITLE
Fix #157, Apply formatting

### DIFF
--- a/Subsystems/cmdUtil/SendUdp.c
+++ b/Subsystems/cmdUtil/SendUdp.c
@@ -44,7 +44,7 @@ int SendUdp(char *hostname, char *portNum, unsigned char *packetData, int packet
     struct addrinfo  hints;
     struct addrinfo *result;
     struct addrinfo *rp;
-    char             hbuf[1025] = {0};
+    char             hbuf[1025] = "UNKNOWN";
 
     if (hostname == NULL)
     {
@@ -94,7 +94,7 @@ int SendUdp(char *hostname, char *portNum, unsigned char *packetData, int packet
         return -4;
     }
 
-    if (getnameinfo(rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), NULL, 0, NI_NUMERICHOST));
+    getnameinfo(rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), NULL, 0, NI_NUMERICHOST);
     printf("sending data to '%s' (IP : %s); port %d\n", rp->ai_canonname, hbuf, port);
 
     freeaddrinfo(result);

--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -252,7 +252,8 @@ void DisplayUsage(char *Name)
     printf("  ./cmdUtil -ELE -C2 -A6 -n2 # Processor reset on little endian, using defaults\n");
     printf("  ./cmdUtil --endian=LE --protocol=raw --uint64b=0x1806C000000302DD --uint16=2\n");
     printf("  ./cmdUtil --pktver=1 --pkttype=0 --pktsec=0 --pktseqflg=2 --pktlen=0xABC --pktcksum=0\n");
-    printf("  ./cmdUtil -Qcfsv2 --pktedsver=0xA --pktendian=1 --pktpb=1 --pktsubsys=0x123 --pktsys=0x4321 --pktfc=0xB\n");
+    printf(
+        "  ./cmdUtil -Qcfsv2 --pktedsver=0xA --pktendian=1 --pktpb=1 --pktsubsys=0x123 --pktsys=0x4321 --pktfc=0xB\n");
     printf(" \n");
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #157 - applies formatting, removed an "if" that didn't do anything and initialized the reported IP to UNKNOWN if `getnameinfo` doesn't work.

**Testing performed**
Built and ran cmdUtil

**Expected behavior changes**
Reports `UNKNOWN` if getnameinfo doesn't work.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC