### PR TITLE
cFS-GroundSystem Integration candidate: 2021-02-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,40 @@ See [Guide-GroundSystem.md](https://github.com/nasa/cFS-GroundSystem/blob/master
 
 ## Version History
 
-### Development Build: 2.2.0-rc1+dev18
+### Development Build: v2.2.0-rc1+dev29
+
+- Removes unnecessary type translations from `CHeaderParser.py` and broken `double` option. `uint64` will no longer get translated by `CHeaderParser` into the unsupported `double` type
+- See <https://github.com/nasa/cfs-groundsystem/pull/162>
+
+### Development Build: v2.2.0-rc1+dev18
 
 - Documentation: Add `Security.md` with instructions to report vulnerabilities
 - **Breaking change**, CmdUtil, Rounds header up to match <https://github.com/nasa/cFE/pull/1077>
 - **Breaking change**, GUI, Rounds header up to match <https://github.com/nasa/cFE/pull/1077>
 - See <https://github.com/nasa/cFS-GroundSystem/pull/150>
 
-### Development Build: 2.2.0-rc1+dev11
+### Development Build: v2.2.0-rc1+dev11
 
 - Updated CHeaderParser.py to address specific issues.
 - See <https://github.com/nasa/cFS-GroundSystem/pull/135>
 
-### Development Build: 2.2.0-rc1+dev8
+### Development Build: v2.2.0-rc1+dev8
 
 - Replaces old code that caused a cast-align warning when strict. Refactored and removed unnecessary code while also following recommended model for getaddrinfo. Removed old windows support/defines/etc (likely not tested for years, no longer supported).
 - Reduce the size of the strncpy so that it ensures there's a null byte at the end of the string buffer.
 - See <https://github.com/nasa/cFS-GroundSystem/pull/133>
 
-### Development Build: 2.2.0+dev2
+### Development Build: v2.2.0+dev2
 
  - Fixes multiple typos
 - See <https://github.com/nasa/cFS-GroundSystem/pull/127>
 
-### Development Build: 2.1.0+dev85
+### Development Build: v2.1.0+dev85
 
 - Remove unused code/packages to fix LGTM warnings
 - See <https://github.com/nasa/cFS-GroundSystem/pull/120>
 
-### Development Build: 2.1.0+dev76
+### Development Build: v2.1.0+dev76
 
 - Fixes more lgtm warnings
 - Allows users to change the byte offsets for sending commands and parsing telemetry, to support different header versions or other implementations of cFS

--- a/Subsystems/cmdGui/CHeaderParser.py
+++ b/Subsystems/cmdGui/CHeaderParser.py
@@ -68,19 +68,15 @@ ROOTDIR = Path(sys.argv[0]).resolve().parent
 
 
 #
-# Determines data type (--string, --byte, --half, --word, --double)
+# Translate known data types to arguments
 #
 def findDataTypeNew(dataTypeOrig, paramName):
     if '[' in paramName:
         return '--string'
-    if dataTypeOrig in ['uint8', 'boolean']:
-        return '--byte'
-    if dataTypeOrig == 'uint16':
-        return '--half'
-    if dataTypeOrig == 'uint32':
-        return '--word'
-    if dataTypeOrig == 'uint64':
-        return '--double'
+    if dataTypeOrig in ['boolean']:
+        return '--uint8'
+    if dataTypeOrig in ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64']:
+        return "--" + dataTypeOrig
     return None
 
 

--- a/_version.py
+++ b/_version.py
@@ -20,7 +20,7 @@
 #
 
 # Development Build Macro Definitions
-_cFS_GrndSys_build_number = 18
+_cFS_GrndSys_build_number = 29
 _cFS_GrndSys_build_baseline = "v2.2.0-rc1"
 
 # Version Number Definitions


### PR DESCRIPTION
**Describe the contribution**
 Fix #155, Remove unnecessary type translations

**Testing performed**
See <https://github.com/nasa/cFS/pull/193/checks>

**Expected behavior changes**
PR #156 - Removes unnecessary type translations from `CHeaderParser.py` and broken `double` option. `uint64` will no longer get translated by `CHeaderParser` into the unsupported `double` type

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/193>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@skliper 