### PR TITLE
Fix #165, Updated TBL and SB tlm for an operational TLM display

### DIFF
--- a/Subsystems/tlmGUI/cfe-sb-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-sb-hk-tlm.txt
@@ -1,17 +1,17 @@
 #
-Command Counter,               16,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Error Counter,                 17,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
-NoSubscribersCounter,          18,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
-MsgSendErrorCounter,           19,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-MsgReceiveErrorCounter,        20,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-InternalErrorCounter,          21,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-CreatePipeErrorCounter,        22,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-SubscribeErrorCounter,         23,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-PipeOptsErrorCounter,          24,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-DuplicateSubscriptionsCounter, 25,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Spare2Align,                   26,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
-PipeOverflowErrorCounter,      28,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
-MsgLimitErrorCounter,          30,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
-MemPoolHandle,                 32,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-MemInUse,                      36,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-UnmarkedMem,                   40,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Command Counter,               12,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Error Counter,                 13,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+NoSubscribersCounter,          14,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+MsgSendErrorCounter,           15,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+MsgReceiveErrorCounter,        16,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+InternalErrorCounter,          17,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+CreatePipeErrorCounter,        18,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+SubscribeErrorCounter,         19,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+PipeOptsErrorCounter,          20,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+DuplicateSubscriptionsCounter, 21,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Spare2Align,                   22,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+PipeOverflowErrorCounter,      24,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+MsgLimitErrorCounter,          36,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+MemPoolHandle,                 28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+MemInUse,                      32,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+UnmarkedMem,                   36,  4,  I, Dec, NULL,        NULL,        NULL,       NULL

--- a/Subsystems/tlmGUI/cfe-tbl-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-tbl-hk-tlm.txt
@@ -15,24 +15,24 @@
 #  Note(1): A line that begins with # is a comment
 #  Note(2): Remove any blank lines from the end of the file
 #
-Command Counter,       16,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Error Counter,         17,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
-Num tables,            18,  2,  H, Dec, NULL,        NULL,        NULL,       NULL  
-Num load pending,      20,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
-Validation cnt,        22,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
-Last valid CRC,        24,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Last valid status,     28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Active buffer,         32,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Last valid tbl,        33, 40,  s, Str, NULL,        NULL,        NULL,       NULL
-Success count,         73,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Failed count,          74,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Num requests,          75,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Num free bufs,         76,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-pad1,                  77,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Mem pool hdl,          78,  4,  I, Hex, NULL,        NULL,        NULL,       NULL
-Last upd (secs),       82,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Last upd (subs),       86,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Last upd table name,   90, 40,  s, Str, NULL,        NULL,        NULL,       NULL
-Last file loaded,     130, 64,  s, Str, NULL,        NULL,        NULL,       NULL
-Last file dumped,     194, 64,  s, Str, NULL,        NULL,        NULL,       NULL
-LastTableLoaded,      258, 40,  s, Str, NULL,        NULL,        NULL,       NULL
+Command Counter,       12,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Error Counter,         13,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+Num tables,            14,  2,  H, Dec, NULL,        NULL,        NULL,       NULL  
+Num load pending,      16,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+Validation cnt,        18,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+Last valid CRC,        20,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Last valid status,     24,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Active buffer,         28,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Last valid tbl,        29, 40,  s, Str, NULL,        NULL,        NULL,       NULL
+Success count,         69,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Failed count,          70,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Num requests,          71,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Num free bufs,         72,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+pad1,                  73,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Mem pool hdl,          74,  4,  I, Hex, NULL,        NULL,        NULL,       NULL
+Last upd (secs),       78,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Last upd (subs),       82,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Last upd table name,   86, 40,  s, Str, NULL,        NULL,        NULL,       NULL
+Last file loaded,     126, 64,  s, Str, NULL,        NULL,        NULL,       NULL
+Last file dumped,     190, 64,  s, Str, NULL,        NULL,        NULL,       NULL
+LastTableLoaded,      254, 40,  s, Str, NULL,        NULL,        NULL,       NULL


### PR DESCRIPTION
**Describe the contribution**
A clear and concise description of what the contribution is.
- The telemetry pages for SB and TBL do not load when selected to open as it creates a buffer error. (Issue #165)
- Fix: Updates values to correct values for each subsystem

**Testing performed**
1. Ran the ground system: make (in cmdUtil)
2. python3 GroundSystem.py
3. Started Telemetry (with TLM enabled)
4. Opened Tlm for TBL and SB
5. Additionally tested rest of TLM system

**Expected behavior changes**
- Will allow for the TBL and SB tlm pages to open.

**System(s) tested on**
    RPi 3B+
    OS: Raspberry Pi OS, formally Raspbian
    Versions [Bundle main]

**Additional context**

**Third party code**

**Contributor Info - All information REQUIRED for consideration of pull request**
Evan Fitzgerald (Personal)
