### PR TITLE
Fix #169, Add Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+Please see our [top-level contributing guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md) for more information on how to contribute. 


### PR DESCRIPTION
**Describe the contribution**
Fix #169 
Added a contributing guide that links to the main cFS contributing guide. 

**Expected behavior changes**
Users should be able to view the contributing guide contents easily from the cFS-GroundSystem repo. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal