### PR TITLE
fix #172, updating executable name and version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup
+from _version import __version__ as _version
 
 setup(
-        name='GroundSystem',
+        name='cFS-GroundSystem',
         packages=['Subsystems','Subsystems.tlmGUI','Subsystems.cmdGui','Subsystems.cmdUtil'],
         include_package_data=True,
-        version='0.0.0',
+        version=_version,
         entry_points={
             'console_scripts':[
-                'startg=GroundSystem:main'
+                'cFS-GroundSystem=GroundSystem:main'
                 ]
             },
         )


### PR DESCRIPTION
**Describe the contribution**
A clear and concise description of what the contribution is.
-Changing executable command from 'startg' to 'cFS-GroundSystem'
-Changing version to be the version stated in version.py


**Testing performed**
Steps taken to test the contribution:
made sure new executable command works 

**Expected behavior changes**
Changing executable command from 'startg' to 'cFS-GroundSystem'

**System(s) tested on**
 - Hardware: MacBook Pro 
 - OS: macOS Big Sur
 - Versions: 11.2.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Zachary Gonzalez - Personal
