### PR TITLE
cFS-Ground System Integration candidate: 2021-04-20

### DIFF
--- a/Guide-GroundSystem.md
+++ b/Guide-GroundSystem.md
@@ -39,6 +39,14 @@ Installing and running cFS Ground System on Ubuntu:
 
 The historically included instructions for running on macOS or CentOS are included at the bottom of this document for reference. Please note that instructions have not been maintained. Welcoming instruction contributions if any of these are your platform of choice.
 
+### Install Ground System executable
+This works for both macOS and Ubuntu systems.
+```
+The requirements.txt file is located directly inside the cFS-GroundSystem/
+$ pip3 install -r requirements.txt
+$ pip3 install -e relative/path/to/cFS-GroundSystem
+$ cFS-GroundSystem
+```
 ## Adding new flight software application to ground system command GUI
 
 This section was made to help developers who are adding core Flight Software (cFS) Applications to the Python-based Ground System that comes with this cFS distribution.
@@ -157,3 +165,4 @@ $ yum install -y qt qt-demos qt-designer qt4 qt4-designer
 ```
 $ python GroundSystem.py
 ```
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ See [Guide-GroundSystem.md](https://github.com/nasa/cFS-GroundSystem/blob/master
 
 ## Version History
 
+### Development Build: v2.2.0-rc1+dev45
+
+- Changes executable command from 'startg' to 'cFS-GroundSystem'
+- Changes version to be the version stated in version.py
+- Adds executable installation instructions to Guide-GroundSystem.md
+- See <https://github.com/nasa/cFS-GroundSystem/pull/178> and <https://github.com/nasa/cFS/pull/248>
+
 ### Development Build: v2.2.0-rc1+dev41
 
 - Corrects values in sb and tbl hk-tlm.txt to allow the TBL and SB tlm pages to open.

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup
+from _version import __version__ as _version
 
 setup(
-        name='GroundSystem',
+        name='cFS-GroundSystem',
         packages=['Subsystems','Subsystems.tlmGUI','Subsystems.cmdGui','Subsystems.cmdUtil'],
         include_package_data=True,
-        version='0.0.0',
+        version=_version,
         entry_points={
             'console_scripts':[
-                'startg=GroundSystem:main'
+                'cFS-GroundSystem=GroundSystem:main'
                 ]
             },
         )


### PR DESCRIPTION
## Description

### PR #174 

Fix #172, update executable name and version in setup.py (#174)

Changes executable command from 'startg' to 'cFS-GroundSystem'
Changes version to be the version stated in version.py

### PR #175 

Fix #173, Add executable install guide 

Adds executable installation instructions to Guide-GroundSystem.md

## Context

Part of <https://github.com/nasa/cfs/pull/248>

## Testing
cFS-GroundSystem checks <https://github.com/nasa/cFS-GroundSystem/pull/178/checks>
cFS Bundle Checks <https://github.com/nasa/cfs/pull/248/checks>

## Author
@zachar1a 