### PR TITLE
Fix #179, Implement Coding Standard in CodeQL

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,9 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   push:
+  pull_request:
     branches:
       - main
-  pull_request:
 
 env:
   SIMULATION: native
@@ -13,8 +13,23 @@ env:
   BUILDTYPE: release
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
-  CodeQL-Build:
+  CodeQL-Security-Build:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-18.04
     timeout-minutes: 15
 
@@ -38,7 +53,49 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
          languages: c
-         queries: +security-extended, security-and-quality
+         config-file: nasa/cFS/.github/codeql/codeql-security.yml@main
+
+      # Setup the build system
+      - name: Set up for build
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+          make prep
+
+      # Build the code
+      - name: Build
+        run: make tools/cFS-GroundSystem/Subsystems/cmdUtil/
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+  CodeQL-Coding-Standard-Build:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout bundle
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+        with:
+          path: tools/cFS-GroundSystem
+
+      - name: Check versions
+        run: git submodule
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+         languages: c
+         config-file: nasa/cFS/.github/codeql/codeql-coding-standard.yml@main
 
       # Setup the build system
       - name: Set up for build


### PR DESCRIPTION
**Describe the contribution**
Fix #179 
Added the duplicate jobs action to avoid duplicate jobs from running. Added a separate job for coding standard queries. Created two configuration files, one for default queries and security queries and another for jpl rules. Removed push on main branch so when users push code to their forked repos, the workflow runs. Added main branch to pull request, so CodeQL runs on pull request made in the main branch. This is the same logic used in the cFS bundle repo. 

**Testing performed**
Testing done on cFE forked repository, ArielSAdamsNASA/cFE which used the same files, but with different configuration paths.

Jobs were failing when the entire path of the configuration file were not used. Have to use nasa/cFE/.github/codeql/config-name@branch-name. The branch must be included in the path. 

The CodeQL analysis workflow will fail for this PR since it is calling for a configuration file in main the main branch. It will not work until the configuration files are merged into main. 

In the screenshot is the same workflow as in this pull request, but the configuration path is changed to the forked repo and tested branch. 

![image](https://user-images.githubusercontent.com/69638935/119024913-36fa2580-b969-11eb-9aac-ede0002804a0.png)

**Expected behavior changes**
There should be one job for security queries and one job for JPL and MISRA queries. 

**Describe alternatives you've considered**
Can allow all branches to run CodeQL for pull requests as seen in cFE and PSP instead of just the main branch like cFS. 

**Third party code**
Skip duplicate workflows license: https://github.com/fkirc/skip-duplicate-actions/blob/master/LICENSE

CodeQL license: https://github.com/github/codeql-action/blob/main/LICENSE

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal