### PR TITLE
Fix #149, * might be referenced before assignment

### DIFF
--- a/Subsystems/tlmGUI/GenericTelemetry.py
+++ b/Subsystems/tlmGUI/GenericTelemetry.py
@@ -52,6 +52,7 @@ class SubsystemTelemetry(QDialog, Ui_GenericTelemetryDialog):
     #
     def displayTelemetryItem(self, datagram, tlmIndex, labelField, valueField):
         if tlmItemIsValid[tlmIndex]:
+            tlmOffset = 0
             try:
                 tlmOffset = self.mm[0]
             except ValueError:
@@ -59,6 +60,8 @@ class SubsystemTelemetry(QDialog, Ui_GenericTelemetryDialog):
             TlmField1 = tlmItemFormat[tlmIndex]
             if TlmField1[0] == "<":
                 TlmField1 = TlmField1[1:]
+
+            itemStart = 0
             try:
                 itemStart = int(tlmItemStart[tlmIndex]) + tlmOffset
             except UnboundLocalError:


### PR DESCRIPTION
**Describe the contribution**
- Fixes #149 
- The problem was that itemStart and tlmOffset were initialized and declared in a try-catch block and if it fails, it could be that itemStart or tlmOffset is not available.

**Testing performed**
 1. IDE stops throwing this warning after the change

**Expected behavior changes**
 - stop throwing an UnboundLocalError for some people

**Contributor Info - All information REQUIRED for consideration of pull request**
Paul Oberosler, Individual
