### PR TITLE
Fix #227, Add input so users can specify the parameter description

### DIFF
--- a/Subsystems/cmdGui/CHeaderParser.py
+++ b/Subsystems/cmdGui/CHeaderParser.py
@@ -407,9 +407,8 @@ if __name__ == '__main__':
                     # Get rid of any occurance of ';' (at the end of the line)
                     param_names.append(re.sub(';', '', line_split[1]))
 
-                    # Not sure about why we are keeping track of this yet
-                    # just fill it with null for now
-                    param_desc.append('')
+                    # Input to add param description
+                    param_desc.append(input('Please enter parameter description: '))
 
                     # Determines data type for us to use
                     # returns null if no type could match


### PR DESCRIPTION
**Describe the contribution**
The default behavior for the param description was to be considered null. However I found this not to be very user friendly since if you didn't have the source code with the accepted values you couldn't create a valid command to send.
My solution was to add an input after specifying a parameter in order for the description of the parameter to be saved.
This way when we open GroundSystem and start creating a command to send, we have some guidelines about the acceptable inputs for the arguments

Screenshot of how the GUI has been affected:
https://ibb.co/9TKXB51

**Testing performed**
Steps taken to test the contribution:
1. Parse document with CHeaderParser.py
2. After selecting line for parameter to add, write (or not) a short description of the values that are acceptable

**Expected behavior changes**
 - Behavior Change: now when we open Ground System the column with the description for the params will be filled instead of the default null which makes it more user friendly

**System(s) tested on**
 - OS: Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Hugo Micael Santos Valente / STRAST / UPM
