### PR TITLE
Fix #221, Remove 'return;' from last line of void functions.

### DIFF
--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -366,8 +366,6 @@ void ProcessField(uint16_t *orig, const char *in, const uint16_t mask, bool fiel
     }
 
     *orig = htobe16((be16toh(*orig) & ~mask) | (templong & mask));
-
-    return;
 }
 
 /******************************************************************************
@@ -387,8 +385,6 @@ void CopyData(unsigned char *pkt, unsigned int *startbyte, char *in, unsigned in
     /* Copy data into packet buffer and move start byte */
     memcpy(&pkt[*startbyte], in, nbytes);
     *startbyte += nbytes;
-
-    return;
 }
 
 /******************************************************************************


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #221
Removes all cases of redundant "return;" statements on the last line of void functions.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 