### PR TITLE
Fix #234, Update incorrect variable descriptions in tlm.txt

### DIFF
--- a/Subsystems/tlmGUI/cfe-es-app-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-es-app-tlm.txt
@@ -1,6 +1,6 @@
-Name,                 20, 20,  s, Str, NULL,        NULL,        NULL,       NULL
-EntryPoint,           40, 20,  s, Str, NULL,        NULL,        NULL,       NULL
-FileName,             60, 64,  s, Str, NULL,        NULL,        NULL,       NULL
+Name,                 20,  20,  s, Str, NULL,        NULL,        NULL,       NULL
+EntryPoint,           40,  20,  s, Str, NULL,        NULL,        NULL,       NULL
+FileName,             60,  64,  s, Str, NULL,        NULL,        NULL,       NULL
 StackSize,            124,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 ModuleId,             128,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 AddressesAreValid,    132,  4,  I, Dec, NULL,        NULL,        NULL,       NULL

--- a/Subsystems/tlmGUI/cfe-sb-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-sb-hk-tlm.txt
@@ -1,7 +1,7 @@
 #
 Command Counter,               12,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Error Counter,                 13,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
-NoSubscribersCounter,          14,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+Error Counter,                 13,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+NoSubscribersCounter,          14,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 MsgSendErrorCounter,           15,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 MsgReceiveErrorCounter,        16,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 InternalErrorCounter,          17,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
@@ -9,7 +9,8 @@ CreatePipeErrorCounter,        18,  1,  B, Dec, NULL,        NULL,        NULL, 
 SubscribeErrorCounter,         19,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 PipeOptsErrorCounter,          20,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 DuplicateSubscriptionsCounter, 21,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Spare2Align,                   22,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
+GetPipeIdByNameErrorCounter,   22,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Spare2Align,                   23,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 PipeOverflowErrorCounter,      24,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
 MsgLimitErrorCounter,          36,  2,  H, Dec, NULL,        NULL,        NULL,       NULL
 MemPoolHandle,                 28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL

--- a/Subsystems/tlmGUI/cfe-tbl-reg-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-tbl-reg-tlm.txt
@@ -1,9 +1,9 @@
-Size,                       4,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Crc,                        8,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Size,                       4,   4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Crc,                        8,   4,  I, Dec, NULL,        NULL,        NULL,       NULL
 ActiveBufferAddr,           12,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 InactiveBufferAddr,         16,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 ValidationFuncPtr,          20,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 TimeOfLastUpdate.seconds,   24,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 TimeOfLastUpdate.subsecs,   28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
 FileCreateTimeSecs,         32,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-FileCreateTimeSecs,         36,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+FileCreateTimeSubSecs,      36,  4,  I, Dec, NULL,        NULL,        NULL,       NULL

--- a/Subsystems/tlmGUI/cfs-ful-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfs-ful-hk-tlm.txt
@@ -1,10 +1,10 @@
-Error Counter,       		12,  1,  B,   Dec, NULL,        NULL,        NULL,       NULL
+Error Counter,          12,  1,  B,   Dec, NULL,        NULL,        NULL,       NULL
 Command Counter,        13,  1,  B,   Dec, NULL,        NULL,        NULL,       NULL
-Transfer in progress?,    14,  2,  H,   Dec, NULL,        NULL,        NULL,       NULL
-Last Segment Accepted, 16,  2,  H,    Dec, NULL,        NULL,        NULL,       NULL
-Segments Rejected,       18,  2,  H,    Dec, NULL,        NULL,        NULL,       NULL
-Bytes Transferred,          20,  4,  I,     Dec, NULL,        NULL,        NULL,       NULL
-Current File Name,         24,  64, 64s, Str, NULL,        NULL,        NULL,       NULL
-Current File Size,     	88, 4,  I,   Dec, NULL,        NULL,        NULL,       NULL
-Current File Crc,      	92, 4,  I,   Dec, NULL,        NULL,        NULL,       NULL
-Current File Fd,       	96, 4,  i,   Dec, NULL,        NULL,        NULL,       NULL
+Transfer in progress?,  14,  2,  H,   Dec, NULL,        NULL,        NULL,       NULL
+Last Segment Accepted,  16,  2,  H,   Dec, NULL,        NULL,        NULL,       NULL
+Segments Rejected,      18,  2,  H,   Dec, NULL,        NULL,        NULL,       NULL
+Bytes Transferred,      20,  4,  I,   Dec, NULL,        NULL,        NULL,       NULL
+Current File Name,      24,  64, 64s, Str, NULL,        NULL,        NULL,       NULL
+Current File Size,     	88,  4,  I,   Dec, NULL,        NULL,        NULL,       NULL
+Current File Crc,      	92,  4,  I,   Dec, NULL,        NULL,        NULL,       NULL
+Current File Fd,       	96,  4,  i,   Dec, NULL,        NULL,        NULL,       NULL

--- a/Subsystems/tlmGUI/cfs-nav-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfs-nav-hk-tlm.txt
@@ -8,9 +8,9 @@ Longitude,             48,  8,  d,   Dec, NULL,        NULL,        NULL,       
 Longitude Direction,   56,  4,  4s,  Str, NULL,        NULL,        NULL,       NULL
 Speed,                 64,  8,  d,   Dec, NULL,        NULL,        NULL,       NULL
 Direction,             72,  8,  d,   Dec, NULL,        NULL,        NULL,       NULL
-Mag X,   	       80,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
-Mag Y,   	       82,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
-Mag Z,   	       84,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
-Accel X,	       86,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
-Accel Y,	       88,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
-Accel Z,	       90,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Mag X,   	           80,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Mag Y,   	           82,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Mag Z,   	           84,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Accel X,	           86,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Accel Y,	           88,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL
+Accel Z,	           90,  2,  h,   Dec, NULL,        NULL,        NULL,       NULL


### PR DESCRIPTION
**Describe the contribution**
- Fixes #234 
  - Missing and misnamed/sized variables corrected in the tlm.txt files.

**Testing performed**
GitHub CI actions all passing successfully, and local test confirmed added variable appearing correctly in the GUI:  

![Screenshot 2023-03-22 20 24 54](https://user-images.githubusercontent.com/9024662/226881587-b1a4e6e7-0cd3-40b8-b626-7d41d8dfc521.png)

**Expected behavior changes**
Correct variables appear in the GUI now for these HK telemetry struct variables.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt