### PR TITLE
Fix #220, Add missing description fields to cfe-es-hk-tlm.txt

### DIFF
--- a/Subsystems/tlmGUI/cfe-es-hk-tlm.txt
+++ b/Subsystems/tlmGUI/cfe-es-hk-tlm.txt
@@ -41,9 +41,13 @@ OSAL Major Version,    20,  1,  B, Dec, NULL,        NULL,        NULL,       NU
 OSAL Minor Version,    21,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 OSAL Revision,         22,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
 OSAL Mission Rev,      23,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
-Syslog Bytes Used,     24,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Syslog Size,           28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Syslog Entries,        32,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-Syslog Mode,           36,  4,  I, Enm, LogMode0,    LogMode1,    LogMode2,   LogMode3 
-ERlog Index,           40,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
-ERlog Entries,         44,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+PSPMajorVersion,       24,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+PSPMinorVersion,       25,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+PSPRevision,           26,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+PSPMissionRevision,    27,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Syslog Bytes Used,     28,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Syslog Size,           32,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Syslog Entries,        36,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+Syslog Mode,           40,  4,  I, Enm, LogMode0,    LogMode1,    LogMode2,   LogMode3 
+ERlog Index,           44,  4,  I, Dec, NULL,        NULL,        NULL,       NULL
+ERlog Entries,         48,  4,  I, Dec, NULL,        NULL,        NULL,       NULL


### PR DESCRIPTION
**Describe the contribution**
- Fixes #220 
  - Missing struct members added (PSP version info) to `cfe-es-hk-tlm.txt`

**Testing performed**
GitHub CI actions passing successfully, and local test confirms ES HK Telemetry window is now opening, displaying and updating as expected:  

![Screenshot 2023-03-22 22 20 56](https://user-images.githubusercontent.com/9024662/226904659-3bae00d5-0bb0-418c-b5ab-c20befc084ab.png)
![Screenshot 2023-03-22 22 21 19](https://user-images.githubusercontent.com/9024662/226903807-47010430-8704-4eef-96f6-4dcf71292864.png)

**Expected behavior changes**
ES HK Telemetry window now operating as expected in the Ground System GUI.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt