### PR TITLE
Fix #238, updating cFS_GroundSystem to use new versioning system.

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -18,7 +18,9 @@
 
 # Development Build Macro Definitions
 _cFS_GrndSys_build_number = 43
-_cFS_GrndSys_build_baseline = "v3.0.0-rc4"
+_cFS_GrndSys_build_baseline = "equuleus-rc1"
+_cFS_GrndSys_build_dev_cycle = "equuleus-rc2"
+_cFS_GrndSys_build_codename = "Equuleus"
 
 # Version Number Definitions see doxygen docs for definitions
 _cFS_GrndSys_MAJOR = 2 # Major version number 
@@ -31,7 +33,7 @@ _cFS_GrndSys_REVISION = 0 # Revision version number
 # Reserved for mission use to denote patches/customizations as needed.
 # Values 1-254 are reserved for mission use to denote patches/customizations as # needed. NOTE: Reserving 0 and 0xFF for cFS open-source development use 
 # (pending resolution of nasa/cFS#440)
-_cFS_GrndSys_MISSIONREV = 255 
+_cFS_GrndSys_MISSIONREV = 255
 
 # Development Build format for __version__
 # Baseline git tag + Number of commits since baseline


### PR DESCRIPTION
**Describe the contribution**
Fixes #238.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "_cFS_GrndSys_build_dev_cycle" has been defined
4. Version String has not been removed, as Python is interpreted and this will be recomputed every time it is accessed

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC