### PR TITLE
Fix #244, making version string PEP 440-compliant

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -18,7 +18,8 @@
 
 # Development Build Macro Definitions
 _cFS_GrndSys_build_number = 2
-_cFS_GrndSys_build_baseline = "equuleus-rc1"
+_cFS_GrndSys_build_baseline = "7.2"
+_cFS_GrndSys_build_dev_baseline = "equuleus-rc1"
 _cFS_GrndSys_build_dev_cycle = "equuleus-rc2"
 _cFS_GrndSys_build_codename = "Equuleus"
 
@@ -37,7 +38,7 @@ _cFS_GrndSys_MISSIONREV = 255
 
 # Development Build format for __version__
 # Baseline git tag + Number of commits since baseline
-__version__ = "+dev".join((_cFS_GrndSys_build_baseline,str(_cFS_GrndSys_build_number)))
+__version__ = "+".join((_cFS_GrndSys_build_baseline, _cFS_GrndSys_build_dev_baseline + "_dev" + str(_cFS_GrndSys_build_number)))
 
 # Development Build format for __version_string__
 _version_string = " cFS-GroundSystem DEVELOPMENT BUILD\n " + __version__


### PR DESCRIPTION
**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #244, which was occurring due to the versioning system introduced in #238 not being [PEP 440](https://peps.python.org/pep-0440/)-compliant

**Testing performed**
Followed instructions in [Install Ground System executable](https://github.com/nasa/cFS-GroundSystem/blob/main/Guide-GroundSystem.md#install-ground-system-executable) section of [Guide-GroundSystem.md](https://github.com/nasa/cFS-GroundSystem/blob/main/Guide-GroundSystem.md).

**Expected behavior changes**
pip install command now works.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker - NASA GSFC