### PR TITLE
Fix misleading wording in Commands-Telemetry.md

### DIFF
--- a/Subsystems/Commands-Telemetry.md
+++ b/Subsystems/Commands-Telemetry.md
@@ -3,7 +3,8 @@
 ## Telemetry ( tlmGUI/ directory ):
 Telemetry is sent from the running cFE/CFS as CCSDS telemetry packets encapsulated in 
 UDP/IP packets. The `enable telemetry` command tells the TO_LAB application to start 
-sending packets to a UDP port (port #1234 by default) on the `localhost` or a specified IP. 
+sending packets to a UDP port on the `localhost` or a specified IP. By default, the TO_LAB application
+listens to UDP port 1234 for commands, and sends telemetry to the tlmGUI at UDP port 1235.
 
 Start the telemetry system using the Ground System's main window.
 


### PR DESCRIPTION
The original wording misleads readers to believe that the default port for receiving telemetry is 1234, in reality it being 1235, and the former being the port that the telemetry app uses to listen for commands.

**Describe the contribution**
Fixes #248 by improving the wording and adding information obtained by research

**Testing performed**
Tested using `ss` and `tcpdump` to track listening ports and sent packets. Proof can be found in the addressed issue.

**Expected behavior changes**
Readers will hopefully not be mislead in the future and will correctly understand the ports involved.

**System(s) tested on**
Hardware: M1 Ultra chipset
OS: Debian 12.5 ARM64
Versions: cFS-GroundSystem Aquilla release

**Contributor Info - All information REQUIRED for consideration of pull request**
Voicu Ioan-Vladut, Personal