### PR TITLE
Open Source Draco Release

### DIFF
--- a/GroundSystem.py
+++ b/GroundSystem.py
@@ -1,9 +1,9 @@
 # !/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -24,6 +24,7 @@ import sys
 import os
 import signal
 import pathlib
+import getpass
 
 from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox
 
@@ -163,7 +164,7 @@ class GroundSystem(QMainWindow, UiMainWindow):
     def save_offsets(self):
         offsets = bytes((self.sb_tlm_offset.value(), self.sb_cmd_offset_pri.value(),
                          self.sb_cmd_offset_sec.value()))
-        with open("/tmp/OffsetData", "wb") as f:
+        with open(f"/tmp/OffsetData-{getpass.getuser()}", "wb") as f:
             f.write(offsets)
 
     # Update the combo box list in gui

--- a/RoutingService.py
+++ b/RoutingService.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -25,8 +25,10 @@ from time import sleep
 import zmq
 from PyQt5.QtCore import QThread, pyqtSignal
 
+import getpass
+
 # Receive port where the CFS TO_Lab app sends the telemetry packets
-udp_recv_port = 1235
+udp_recv_port = 2234
 
 
 #
@@ -51,7 +53,7 @@ class RoutingService(QThread):
         # Init zeroMQ
         self.context = zmq.Context()
         self.publisher = self.context.socket(zmq.PUB)
-        self.publisher.bind("ipc:///tmp/GroundSystem")
+        self.publisher.bind(f"ipc:///tmp/GroundSystem-{getpass.getuser()}")
 
     # Run thread
     def run(self):

--- a/Subsystems/Commands-Telemetry.md
+++ b/Subsystems/Commands-Telemetry.md
@@ -3,8 +3,9 @@
 ## Telemetry ( tlmGUI/ directory ):
 Telemetry is sent from the running cFE/CFS as CCSDS telemetry packets encapsulated in 
 UDP/IP packets. The `enable telemetry` command tells the TO_LAB application to start 
-sending packets to a UDP port on the `localhost` or a specified IP. By default, the TO_LAB application
-listens to UDP port 1234 for commands, and sends telemetry to the tlmGUI at UDP port 1235.
+sending packets to a UDP port on the `localhost` or a specified IP.
+By default, the cFS listens to UDP port 1234 for commands,
+and sends telemetry to the tlmGUI at UDP port 2234.
 
 Start the telemetry system using the Ground System's main window.
 

--- a/Subsystems/cmdGui/CHeaderParser.py
+++ b/Subsystems/cmdGui/CHeaderParser.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #

--- a/Subsystems/cmdGui/CommandParser.py
+++ b/Subsystems/cmdGui/CommandParser.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #

--- a/Subsystems/cmdGui/CommandSystem.py
+++ b/Subsystems/cmdGui/CommandSystem.py
@@ -1,9 +1,9 @@
 # !/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #

--- a/Subsystems/cmdGui/HTMLDocsParser.py
+++ b/Subsystems/cmdGui/HTMLDocsParser.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #

--- a/Subsystems/cmdGui/MiniCmdUtil.py
+++ b/Subsystems/cmdGui/MiniCmdUtil.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -23,6 +23,7 @@ import mmap
 import socket
 from collections import namedtuple
 
+import getpass
 
 class MiniCmdUtil:
     # Class objects
@@ -61,7 +62,7 @@ class MiniCmdUtil:
         self.parameters = parameters
         self.payload = bytearray()
         self.packet = bytearray()
-        with open("/tmp/OffsetData", "r+b") as f:
+        with open(f"/tmp/OffsetData-{getpass.getuser()}", "r+b") as f:
             self.mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
 
         self.cmd_offset_pri = 0

--- a/Subsystems/cmdGui/Parameter.py
+++ b/Subsystems/cmdGui/Parameter.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #

--- a/Subsystems/cmdGui/UdpCommands.py
+++ b/Subsystems/cmdGui/UdpCommands.py
@@ -1,9 +1,9 @@
 # !/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -18,7 +18,6 @@
 #  limitations under the License.
 #
 
-#
 # UdpCommands.py -- This is a class that creates a simple command dialog and
 #                   sends commands using the cmdUtil UDP C program.
 #

--- a/Subsystems/cmdUtil/SendUdp.c
+++ b/Subsystems/cmdUtil/SendUdp.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/Subsystems/cmdUtil/SendUdp.h
+++ b/Subsystems/cmdUtil/SendUdp.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/Subsystems/cmdUtil/cmdUtil.c
+++ b/Subsystems/cmdUtil/cmdUtil.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/Subsystems/tlmGUI/EventMessage.py
+++ b/Subsystems/tlmGUI/EventMessage.py
@@ -1,9 +1,9 @@
 # !/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -61,6 +61,8 @@ from PyQt5.QtWidgets import QApplication, QDialog
 
 from UiEventmessagedialog import UiEventmessagedialog
 
+import getpass
+
 ROOTDIR = Path(sys.argv[0]).resolve().parent
 
 
@@ -77,7 +79,7 @@ class EventMessageTelemetry(QDialog, UiEventmessagedialog):
             4: "CRITICAL"
         }
 
-        with open("/tmp/OffsetData", "r+b") as f:
+        with open(f"/tmp/OffsetData-{getpass.getuser()}", "r+b") as f:
             self.mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
 
     def init_em_tlm_receiver(self, subscr):
@@ -141,7 +143,7 @@ class EMTlmReceiver(QThread):
         # Init zeroMQ
         self.context = zmq.Context()
         self.subscriber = self.context.socket(zmq.SUB)
-        self.subscriber.connect("ipc:///tmp/GroundSystem")
+        self.subscriber.connect(f"ipc:///tmp/GroundSystem-{getpass.getuser()}")
         subscription_string = f"{subscr}.Spacecraft1.TelemetryPackets.{app_id}"
         self.subscriber.setsockopt_string(zmq.SUBSCRIBE, subscription_string)
 

--- a/Subsystems/tlmGUI/GenericTelemetry.py
+++ b/Subsystems/tlmGUI/GenericTelemetry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -31,6 +31,8 @@ from PyQt5.QtWidgets import (QApplication, QDialog, QHeaderView,
 
 from UiGenerictelemetrydialog import UiGenerictelemetrydialog
 
+import getpass
+
 # ../cFS/tools/cFS-GroundSystem/Subsystems/tlmGUI
 ROOTDIR = Path(sys.argv[0]).resolve().parent
 
@@ -42,7 +44,7 @@ class SubsystemTelemetry(QDialog, UiGenerictelemetrydialog):
     def __init__(self):
         super().__init__()
         self.setupUi(self)
-        with open("/tmp/OffsetData", "r+b") as f:
+        with open(f"/tmp/OffsetData-{getpass.getuser()}", "r+b") as f:
             self.mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
 
     #
@@ -131,7 +133,7 @@ class GTTlmReceiver(QThread):
         # Init zeroMQ
         context = zmq.Context()
         self.subscriber = context.socket(zmq.SUB)
-        self.subscriber.connect("ipc:///tmp/GroundSystem")
+        self.subscriber.connect(f"ipc:///tmp/GroundSystem-{getpass.getuser()}")
         my_tlm_pg_apid = subscr.split(".", 1)
         my_subscription = f"GroundSystem.Spacecraft1.TelemetryPackets.{my_tlm_pg_apid[1]}"
         self.subscriber.setsockopt_string(zmq.SUBSCRIBE, my_subscription)

--- a/Subsystems/tlmGUI/TelemetrySystem.py
+++ b/Subsystems/tlmGUI/TelemetrySystem.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -32,6 +32,8 @@ from PyQt5.QtWidgets import (QApplication, QDialog, QHeaderView, QPushButton,
                              QTableWidgetItem)
 
 from UiTelemetrysystemdialog import UiTelemetrysystemdialog
+
+import getpass
 
 ROOTDIR = Path(sys.argv[0]).resolve().parent
 
@@ -151,7 +153,7 @@ class TSTlmReceiver(QThread):
         # Init zeroMQ
         context = zmq.Context()
         self.subscriber = context.socket(zmq.SUB)
-        self.subscriber.connect("ipc:///tmp/GroundSystem")
+        self.subscriber.connect(f"ipc:///tmp/GroundSystem-{getpass.getuser()}")
         self.subscriber.setsockopt_string(zmq.SUBSCRIBE, subscr)
 
     def run(self):

--- a/Subsystems/tlmGUI/sample-app-hk-tlm.txt
+++ b/Subsystems/tlmGUI/sample-app-hk-tlm.txt
@@ -1,0 +1,21 @@
+# 
+# sample-app-hk-tlm.txt
+# 
+# This file should have the following comma delimited fields:
+#   1. Data item description
+#   2. Offset of data item in packet
+#   3. Length of data item
+#   4. Python data type of item ( using python struct library )
+#   5. Display type of item ( Currently Dec, Hex, Str, Enm ) 
+#   6. Display string for enumerated value 0 ( or NULL if none ) 
+#   7. Display string for enumerated value 1 ( or NULL if none ) 
+#   8. Display string for enumerated value 2 ( or NULL if none ) 
+#   9. Display string for enumerated value 3 ( or NULL if none ) 
+# 
+#  Note(1): A line that begins with # is a comment
+#  Note(2): Remove any blank lines from the end of the file
+#
+Command Counter,     12,  1,  B, Dec, NULL,        NULL,        NULL,       NULL
+Error Counter,   13,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+Spare1,            14,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  
+Spare2,            15,  1,  B, Dec, NULL,        NULL,        NULL,       NULL  

--- a/Subsystems/tlmGUI/telemetry-pages.txt
+++ b/Subsystems/tlmGUI/telemetry-pages.txt
@@ -28,3 +28,4 @@ SB OneSub Tlm,             GenericTelemetry.py,     0x80E,   cfe-sb-onesub-tlm.t
 ES Shell Tlm,              GenericTelemetry.py,     0x80F,   cfe-es-shell-tlm.txt
 ES MEMSTATS Tlm,           GenericTelemetry.py,     0x810,   cfe-es-memstats-tlm.txt
 ES BlockStats Tlm 1,       GenericTelemetry.py,     0x810,   cfe-es-blockstats_1-tlm.txt
+Sample App HK Tlm,         GenericTelemetry.py,     0x883,   sample-app-hk-tlm.txt

--- a/TlmMQRecv.py
+++ b/TlmMQRecv.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -19,6 +19,7 @@
 #
 
 import zmq
+import getpass
 
 
 #
@@ -30,7 +31,7 @@ def main():
     # Prepare our context and publisher
     context = zmq.Context()
     subscriber = context.socket(zmq.SUB)
-    subscriber.connect("ipc:///tmp/GroundSystem")
+    subscriber.connect(f"ipc:///tmp/GroundSystem-{getpass.getuser()}")
     subscriber.setsockopt(zmq.SUBSCRIBE, b"GroundSystem")
 
     while True:

--- a/TlmUDPSender.py
+++ b/TlmUDPSender.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -32,10 +32,8 @@ if __name__ == "__main__":
     while True:
         num += 1
         time.sleep(1)
-        # send_host = "10.1.57.37"
         send_host = "127.0.0.1"
-        # send_host = "192.168.1.4"
-        send_port = 1235
+        send_port = 2234
         datagram = b'Test tlm message'
         send_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         send_socket.sendto(datagram, (send_host, send_port))

--- a/_version.py
+++ b/_version.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #
@@ -17,15 +17,15 @@
 #
 
 # Development Build Macro Definitions
-_cFS_GrndSys_build_number = 18
-_cFS_GrndSys_build_baseline = "7.2"
-_cFS_GrndSys_build_dev_baseline = "equuleus-rc1"
-_cFS_GrndSys_build_dev_cycle = "equuleus-rc2"
-_cFS_GrndSys_build_codename = "Equuleus"
+_cFS_GrndSys_build_number = 0
+_cFS_GrndSys_build_baseline = "7.0"
+_cFS_GrndSys_build_dev_baseline = "v7.0.0"
+_cFS_GrndSys_build_dev_cycle = "v7.0.0"
+_cFS_GrndSys_build_codename = "Draco"
 
 # Version Number Definitions see doxygen docs for definitions
-_cFS_GrndSys_MAJOR = 2 # Major version number 
-_cFS_GrndSys_MINOR = 1 # Minor version number 
+_cFS_GrndSys_MAJOR = 7 # Major version number 
+_cFS_GrndSys_MINOR = 0 # Minor version number 
 _cFS_GrndSys_REVISION = 0 # Revision version number 
 
 
@@ -34,7 +34,7 @@ _cFS_GrndSys_REVISION = 0 # Revision version number
 # Reserved for mission use to denote patches/customizations as needed.
 # Values 1-254 are reserved for mission use to denote patches/customizations as # needed. NOTE: Reserving 0 and 0xFF for cFS open-source development use 
 # (pending resolution of nasa/cFS#440)
-_cFS_GrndSys_MISSIONREV = 255
+_cFS_GrndSys_MISSIONREV = 0
 
 # Development Build format for __version__
 # Baseline git tag + Number of commits since baseline

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #
-#  NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+#  NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
 #
-#  Copyright (c) 2020 United States Government as represented by the
+#  Copyright (c) 2023 United States Government as represented by the
 #  Administrator of the National Aeronautics and Space Administration.
 #  All Rights Reserved.
 #


### PR DESCRIPTION
[NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"](https://github.com/nasa/cFS-GroundSystem/pull/252/commits/9775ccc65cac4b4bf67b1db42a352c4e31a6e9aa)
Batch update of latest cFS software release

Reflects commit 47f7e97a6ed49f9089eb006f2aab18ad36e49c3a from NASA internal development repo