### PR TITLE
Fix #219, Prevent infinite loop when line contains both braces

### DIFF
--- a/Subsystems/cmdGui/CHeaderParser.py
+++ b/Subsystems/cmdGui/CHeaderParser.py
@@ -311,6 +311,10 @@ if __name__ == '__main__':
                             # Now that we know the struct is over, add list of lines
                             # to the sets of command structures
                             list_cmd_structs.append(lines_of_struct)
+
+                            # Advance past the closing brace line so the
+                            # outer loop does not reprocess it (fixes #219)
+                            line_num += 1
                             break
 
                         # Add line number to list


### PR DESCRIPTION
**Describe the contribution**
Fixes #219. When a header line contains both `{` and `}` (e.g. a single-line struct or a comment like `/* {FOO} */`), CHeaderParser enters an infinite loop. The outer loop detects `{` but only increments `line_num` in the `else` branch (no `{` found). The inner loop immediately finds `}` on the same line and breaks, but `line_num` never advances, so the same line is reprocessed forever.

The fix increments `line_num` after processing the closing brace line in the inner loop, so the outer loop always advances past it.

**Testing performed**
- Verified Python syntax with `py_compile`
- Traced all code paths: normal multi-line structs, single-line brace pairs, two-line structs, and end-of-file edge cases

**Expected behavior changes**
Lines containing both `{` and `}` are now processed and skipped correctly instead of hanging the parser. No change to behavior for normal multi-line structs.

**System(s) tested on**
- Hardware: Apple Silicon
- OS: macOS 15

**Contributor Info**
Heath Dutton, Personal