### PR TITLE
Fix #141, Accept hex values in command parameters

### DIFF
--- a/Subsystems/cmdGui/MiniCmdUtil.py
+++ b/Subsystems/cmdGui/MiniCmdUtil.py
@@ -88,7 +88,7 @@ class MiniCmdUtil:
                 items = param.split("=")  # e.g. ["--uint16", "2"]
                 if "--string" not in param:  # non-string param
                     data_type = items[0].strip("-")  # Remove "--" prefix
-                    data_val = int(items[1])
+                    data_val = int(items[1], 0)
                     for key in self.dataTypes:  # Loop thru dictionary keys
                         if data_type in key:  # Check if e.g. "uint16" in key tuple
                             # Get the TypeSignature tuple


### PR DESCRIPTION
**Describe the contribution**
Fixes #141. Command parameters containing hex values (e.g. `0x880`) raise `ValueError: invalid literal for int() with base 10: '0x880'` in `MiniCmdUtil.assemble_payload`, because `int(items[1])` defaults to base 10. This blocks common cases like passing a MsgId to `TO_LAB_ADD_SUBSCRIPTION`.

The fix is one character: `int(items[1], 0)` auto-detects the base from `0x`, `0o`, and `0b` prefixes and otherwise parses as decimal.

**Testing performed**
- Reproduced the exact `ValueError` pre-fix with `--uint16=0x880`
- Post-fix: `--uint16=0x880` and `--uint16=2176` produce identical payload bytes (`0880`)
- Confirmed decimal, negative, zero, octal, and binary literals all parse correctly
- `python3 -m py_compile` passes on the modified file

**Expected behavior changes**
- Behavior Change: `--<type>=<value>` command parameters now accept hex (`0x...`), octal (`0o...`), and binary (`0b...`) prefixes in addition to decimal.
- Minor tradeoff: zero-padded decimals like `007` no longer parse (base-0 rejects them). Not a documented convention in this repo, and Python 3 itself forbids it in source literals.
- No API change.

**System(s) tested on**
- Hardware: Apple Silicon
- OS: macOS 15
- Versions: cFS-GroundSystem main

**Contributor Info**
Heath Dutton, Personal